### PR TITLE
chore: replace Semaphore badge with Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project Initializer
 
-[![Build Status](https://semaphoreci.com/api/v1/fabric8-launcher/launcher-vscode-extension/branches/master/badge.png)](https://semaphoreci.com/fabric8-launcher/launcher-vscode-extension)
+[![Build Status](https://travis-ci.com/fabric8-launcher/launcher-vscode-extension.svg?branch=master)](https://travis-ci.com/fabric8-launcher/launcher-vscode-extension)
 [![Build status](https://ci.appveyor.com/api/projects/status/bndhekqk8lnj0s99?svg=true)](https://ci.appveyor.com/project/fabric8-launcher/launcher-vscode-extension)
 
 ## Overview


### PR DESCRIPTION
We're no longer using Semaphore to build our projects due to some caching issues. Travis is now used instead