### PR TITLE
Provide a specific Camel/Fuse command #21

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
         "Other"
     ],
     "activationEvents": [
-        "onCommand:project.initializer.generate"
+        "onCommand:project.initializer.generate",
+        "onCommand:project.initializer.generate.camelfuse"
     ],
     "main": "./out/extension",
     "contributes": {
@@ -27,6 +28,11 @@
             {
                 "command": "project.initializer.generate",
                 "title": "Generate a project using Project Initializer",
+                "category": "Project"
+            },
+            {
+                "command": "project.initializer.generate.camelfuse",
+                "title": "Generate a Camel/Fuse project using Project Initializer",
                 "category": "Project"
             }
         ],

--- a/src/test/extension.camelfuse.test.ts
+++ b/src/test/extension.camelfuse.test.ts
@@ -1,0 +1,86 @@
+'use strict';
+import * as assert from 'assert';
+import { Catalog } from '../Catalog';
+import * as initializer from '../extension';
+
+suite("Extension Tests for Camel/Fuse", function () {
+
+    test('Should Filter missions with Camel/Fuse runtime support', function() {
+        let catalog = JSON.parse(`
+        {
+            "boosters": [
+                {
+                    "mission": "mission1",
+                    "name": "booster1.1",
+                    "description": "booster1.1",
+                    "runtime": "fuse",
+                    "version": "community"
+                },
+                {
+                    "mission": "mission1",
+                    "name": "booster1.2",
+                    "description": "booster1.2",
+                    "runtime": "camel",
+                    "version": "redhat"
+                },
+                {
+                    "mission": "mission1",
+                    "name": "booster1.3",
+                    "description": "booster1.3",
+                    "runtime": "another",
+                    "version": "another"
+                },
+                {
+                    "mission": "mission2",
+                    "name": "booster2",
+                    "description": "booster2",
+                    "runtime": "another",
+                    "version": "another"
+                }
+            ],
+            "runtimes": [
+                {
+                    "id": "fuse",
+                    "name": "Fuse",
+                    "description": "The Fuse runtime",
+                    "versions": [
+                        {
+                            "id": "community",
+                            "name": "2.21.2 (Community)"
+                        },
+                        {
+                            "id": "redhat",
+                            "name": "7.2.0 (Red Hat Fuse)"
+                        }
+                    ]
+                }
+            ],
+            "missions": [
+                {
+                    "id": "mission1",
+                    "name": "mission1",
+                    "description": "mission1"
+                },
+                {
+                    "id": "mission2",
+                    "name": "mission2",
+                    "description": "mission2"
+                }
+            ]
+        }`);
+        let filteredCatalog = initializer.filterCatalogForCamelFuse(catalog);
+        assert.ok(filteredCatalog.missions.length === 1);
+        assert.ok(filteredCatalog.missions[0].id === "mission1");
+        assert.ok(filteredCatalog.missions[0].id === "mission1");
+
+        assert.ok(filteredCatalog.boosters.length === 2);
+    });
+    
+    test('Ensure Camel/Fuse runtime id available in Catalog', function() {
+        let catalog = new Catalog('https://forge.api.openshift.io/api/');
+        return catalog.getCatalog().then(res => {
+            assert.ok(res.runtimes.filter((runtime:any) => {return runtime.id === "fuse" || runtime.id === "camel";}).length !== 0);
+        });
+    });
+
+});

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -17,32 +17,31 @@ import { Catalog } from '../Catalog';
 suite("Extension Tests", function () {
 
     test('Extension should be present', () => {
-		assert.ok(vscode.extensions.getExtension('redhat.project-initializer'));
-	});
+        assert.ok(vscode.extensions.getExtension('redhat.project-initializer'));
+    });
 
-	test('should activate', function () {
-		this.timeout(1 * 60 * 1000);
-		return vscode.extensions.getExtension('redhat.project-initializer')!.activate().then((api) => {
-			assert.ok(true);
-		});
-	});
+    test('should activate', function () {
+        this.timeout(1 * 60 * 1000);
+        return vscode.extensions.getExtension('redhat.project-initializer')!.activate().then((api) => {
+            assert.ok(true);
+        });
+    });
 
-	test('should register all commands', function () {
-		return vscode.commands.getCommands(true).then((commands) =>
-		{
-			let myCommands = commands.filter(function(value){
-				return value.startsWith('project.initializer');
-			});
-			assert.equal(myCommands.length, 1, 'Some commands are not registered properly or a new command is not added to the test');
-		});
-	});
+    test('should register all commands', function () {
+        return vscode.commands.getCommands(true).then((commands) =>
+        {
+            let myCommands = commands.filter(function(value){
+                return value.startsWith('project.initializer');
+            });
+            assert.equal(myCommands.length, 2, 'Some commands are not registered properly or a new command is not added to the test');
+        });
+    });
 
-	test('Should load default catalog', function() {
-		let catalog = new Catalog('https://forge.api.openshift.io/api/');
-		return catalog.getCatalog().then(res => {
-			assert.ok(res);
-		})
+    test('Should load default catalog', function() {
+        let catalog = new Catalog('https://forge.api.openshift.io/api/');
+        return catalog.getCatalog().then(res => {
+            assert.ok(res);
+        });
 
-	});
-
+    });
 });


### PR DESCRIPTION
What do you think of this approach?

there are 2 commands:
![image](https://user-images.githubusercontent.com/1105127/53025659-981cb100-3461-11e9-92aa-353735abfd70.png)

the Camel/Fuse is filtering the missions which are providing Camel/Fuse runtime boosters:
![image](https://user-images.githubusercontent.com/1105127/53025689-a965bd80-3461-11e9-9a5c-ea4e9261238a.png)

the "generic" one is still available and working as before:
![image](https://user-images.githubusercontent.com/1105127/53025734-c26e6e80-3461-11e9-9da6-39f402e10f4a.png)




